### PR TITLE
Shutdown script send correct signal based upon RPi model it is running on

### DIFF
--- a/argon1-ubuntu
+++ b/argon1-ubuntu
@@ -113,9 +113,10 @@ else:
     bus = smbus.SMBus(0)
 
 if len(sys.argv) > 1:
-    # TODO: Check this commit, is it required? Perhaps context invocation based on Pi model?
-    # https://github.com/kounch/argonone/commit/973634f5b3795148b03ede2aeaae38b02c05c070
-    bus.write_byte(0x1a,0)
+    if rev == 4:
+        bus.write_byte_data(0x1a,0,0)
+    else:
+        bus.write_byte(0x1a,0)
     if sys.argv[1] == "poweroff" or sys.argv[1] == "halt":
         try:
             bus.write_byte_data(0x1a,0,0xFF)

--- a/argon1-ubuntu
+++ b/argon1-ubuntu
@@ -102,6 +102,11 @@ import smbus
 import RPi.GPIO as GPIO
 
 rev = GPIO.RPI_INFO['P1_REVISION']
+# RPi.GPIO versions prior to 0.7.0 can't identify the RPi 4.
+# The RPi4 is reported as revision 2 so we check the REVISION string
+# to see if it is actually a RPi4.
+if GPIO.VERSION < "0.7.0" and rev == 2 and (GPIO.RPI_INFO['REVISION'][3:5]) == "11":
+    rev = 4
 if rev == 2 or rev == 3:
     bus = smbus.SMBus(1)
 else:
@@ -136,6 +141,11 @@ import time
 from threading import Thread
 
 rev = GPIO.RPI_INFO['P1_REVISION']
+# RPi.GPIO versions prior to 0.7.0 can't identify the RPi 4.
+# The RPi4 is reported as revision 2 so we check the REVISION string
+# to see if it is actually a RPi4.
+if GPIO.VERSION < "0.7.0" and rev == 2 and (GPIO.RPI_INFO['REVISION'][3:5]) == "11":
+    rev = 4
 if rev == 2 or rev == 3:
     bus = smbus.SMBus(1)
 else:

--- a/argon1-ubuntu
+++ b/argon1-ubuntu
@@ -101,7 +101,7 @@ import sys
 import smbus
 import RPi.GPIO as GPIO
 
-rev = GPIO.RPI_REVISION
+rev = GPIO.RPI_INFO['P1_REVISION']
 if rev == 2 or rev == 3:
     bus = smbus.SMBus(1)
 else:
@@ -135,7 +135,7 @@ import os
 import time
 from threading import Thread
 
-rev = GPIO.RPI_REVISION
+rev = GPIO.RPI_INFO['P1_REVISION']
 if rev == 2 or rev == 3:
     bus = smbus.SMBus(1)
 else:

--- a/argon1-ubuntu
+++ b/argon1-ubuntu
@@ -107,7 +107,7 @@ rev = GPIO.RPI_INFO['P1_REVISION']
 # to see if it is actually a RPi4.
 if GPIO.VERSION < "0.7.0" and rev == 2 and (GPIO.RPI_INFO['REVISION'][3:5]) == "11":
     rev = 4
-if rev == 2 or rev == 3:
+if rev == 2 or rev == 3 or rev == 4:
     bus = smbus.SMBus(1)
 else:
     bus = smbus.SMBus(0)
@@ -146,7 +146,7 @@ rev = GPIO.RPI_INFO['P1_REVISION']
 # to see if it is actually a RPi4.
 if GPIO.VERSION < "0.7.0" and rev == 2 and (GPIO.RPI_INFO['REVISION'][3:5]) == "11":
     rev = 4
-if rev == 2 or rev == 3:
+if rev == 2 or rev == 3 or rev == 4:
     bus = smbus.SMBus(1)
 else:
     bus = smbus.SMBus(0)


### PR DESCRIPTION
This PR identifies if the scripts are running on the RPi4 and is so sends the correct signal for the RPi4.

Versions of RPI.GPIO prior to 0.7.0 incorrectly report the RPi4 as revision 2. Ubuntu 18.04 & 20.04 have version 0.6.5 in their repositories. If RPi.GPIO < 0.7.0 is being used and the revision is reported as 2 a check of the revision code string is made to identify whether it is really running on a RPi4.